### PR TITLE
Add UK Government Digital Service role

### DIFF
--- a/uk-gov-gds-open-source-lead.md
+++ b/uk-gov-gds-open-source-lead.md
@@ -1,0 +1,45 @@
+## The Mission 
+
+Over the past five years the UK Government has transformed its relationship with technology, building new teams that can take control of our own destiny, raising the bar for public services on the web and adopting a new, open approach to how we do that. As a result of that effort many contributions have been made to open source projects and a huge amount of government code has been released under open source licenses. 
+
+We now want to build on that work with a more concerted approach to open source (and “inner source”), building collaboration and reuse internally and making higher impact contributions to the wider open source community. There’s an enthusiastic and committed group of developers across government ready to work on this and we are looking for a motivated, visionary individual to lead this effort and take our work to the next level. 
+
+In this role, you’ll work with teams in GDS and across government to help build our open source community, both through driving specific, focused projects and by providing tools and an environment that allow the work to grow and thrive. 
+
+Your day to day responsibilities will alternate between programming, liaising with colleagues from other professions (eg. communications, legal and delivery management), community building and leading projects. This is an exciting opportunity to work with all levels of the organization and leave a lasting impact on how government works. 
+ 
+## Some things you might find yourself doing 
+
+* Establish exemplar projects that are valuable in their own right, but also demonstrate how teams can work together 
+* Lead and streamline all aspects of the outgoing open source process. This encompasses people processes to tooling automation. 
+* Ensure that we have the right tools and public forums to make it easy for all teams to release their code and advertise it to others 
+* Steer involvement and recognition of the open source program internally 
+* Work alongside product and departmental leadership to integrate Open Source goals with GDS and wider government goals, including showing how open source practices can continue to shape the way we work 
+* Build awareness of UK Government Open Source externally and increase overall involvement in the open source community. 
+ 
+ 
+## A good match might have (a) 
+
+* Strong experience coding in software engineering environments, with a strong focus on user needs 
+* Experience working on at least one successful and widely recognized open source project 
+* Excellent communication and organizational skills, including working with non-technical management and leadership 
+* Strong agile delivery management skills 
+* Familiarity with GitHub and other common open source tooling 
+* Understanding of open source licenses 
+* Experience and familiarity with multiple programming languages 
+* Real passion for quality and continuous improvement 
+
+## Civil Service Competencies 
+
+In the Civil Service we use our Competency Framework to outline expected behaviours and we will use these as part of our wider assessment during the interview process. 
+
+For this role, the following competencies are the most relevant:
+* seeing the big picture 
+* delivering at pace 
+* leading and communicating 
+* collaborating and partnering 
+
+Please also give us an indication of the following:
+* Your current salary 
+* You salary expectations 
+* Your current notice period 


### PR DESCRIPTION
This is the JD we used for external advertising. It was accompanied by a more formal JD that meets our internal requirements.