### PR TITLE
Use full name for Apache products

### DIFF
--- a/aiven-open-source-engineering-manager.md
+++ b/aiven-open-source-engineering-manager.md
@@ -4,7 +4,7 @@
 
 Aiven’s exceptional growth is a testament to our ambition in becoming the global category leader in managed cloud data infrastructure. Since its inception six years ago, Aiven’s mission has been to enable customers to drive business results from open source that trigger meaningful transformations for their businesses. We love to operate our favorite tools at scale and empower our customers to do great work. Aiven now has clients on every continent and in over 70 countries globally.
 
-Headquartered in Helsinki with hubs in Berlin, Boston, Sydney, and Toronto, Aiven provides managed open-source data technologies, such as PostgreSQL, Kafka, and M3, on all major clouds. We have raised Series C funding totaling $160M and are backed by world-class investors including Atomico, IVP, and Earlybird Venture Capital, among others. With a recent valuation of $2B, we have become one of the tech world’s most recent unicorns!
+Headquartered in Helsinki with hubs in Berlin, Boston, Sydney, and Toronto, Aiven provides managed open-source data technologies, such as PostgreSQL, Apache Kafka®, and M3, on all major clouds. We have raised Series C funding totaling $160M and are backed by world-class investors including Atomico, IVP, and Earlybird Venture Capital, among others. With a recent valuation of $2B, we have become one of the tech world’s most recent unicorns!
 
 We take pride in how we’ve grown and the positive and passionate working environment we’ve created makes us really excited about what we can achieve in the future. We live our values of openness and ownership every day, and ensure you’ll feel empowered to contribute creatively and meaningfully.
 
@@ -16,7 +16,7 @@ We are now looking for an Engineering Manager for our distributed Open Source Pr
 
 In this role, you will be working with your direct reports as well as with other managers in the OSPO, product managers and company leadership to build the future of Aiven.
 
-You will be leading and enabling a growing team of Open Source developers working remotely. The team focuses on contributing to Open Source projects like Apache Kafka, Apache Flink, OpenSearch, PostgreSQL, and MySQL among many others. People reporting to you will be defined according to your background.
+You will be leading and enabling a growing team of Open Source developers working remotely. The team focuses on contributing to Open Source projects like Apache Kafka®, Apache Flink®, OpenSearch, PostgreSQL, and MySQL among many others. People reporting to you will be defined according to your background.
 
 To succeed in that role, you ideally:
 
@@ -25,7 +25,7 @@ To succeed in that role, you ideally:
 * excel at getting the best out of people and have consistently built great teams through an inspiring and effective leadership style
 * enable and empower your team
 * have experiences with working in a rapidly growing organization
-* have hands on experience with any of the following projects: Apache Kafka, Apache Flink, Apache Cassandra, OpenSearch, PostgreSQL, MySQL, ClickHouse, M3 or Redis
+* have hands on experience with any of the following projects: Apache Kafka®, Apache Flink®, Apache Cassandra®, OpenSearch, PostgreSQL, MySQL, ClickHouse, M3 or Redis
 
 ## Requirements
 


### PR DESCRIPTION
In order to be compliant with Trademark ruling, Apache products need to used in its full form and preferably alongside the registered icon (`®`).