### PR TITLE
Add description of the Community Manager role at @SovereignCloudStack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scs-open-source-community-manager"]
+	path = scs-open-source-community-manager
+	url = git@github.com:itrich/jd-commgr.git


### PR DESCRIPTION
This PR adds the job description and mission statement of the Open Source Community Manager role at the @SovereignCloudStack project. As the document is _living_, I decided to add the underlying repository as a git submodule rather than copying the markdown into this repository. Please let me know if this is not wanted.